### PR TITLE
Disable frame processors and revert camera flow

### DIFF
--- a/app.json
+++ b/app.json
@@ -54,7 +54,7 @@
           "enableCodeScanner": false,
           "enableMicrophonePermission": false,
           "enableLocation": false,
-          "enableFrameProcessors": true
+          "enableFrameProcessors": false
         }
       ],
       [


### PR DESCRIPTION
## Summary
- disable VisionCamera frame processor integration in the Expo config
- revert the camera tab to the Build 16 capture experience without real-time detection wiring

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd4b4e2c008326b5d0de2d6ab47367